### PR TITLE
Fix Missing Displays for Disabled Devices

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -214,8 +214,8 @@ const Future = new Lang.Class({
                       null /* child_setup */);
       this._stdout = new Gio.UnixInputStream({fd: stdout, close_fd: true});
       this._dataStdout = new Gio.DataInputStream({base_stream: this._stdout});
+	  this._stderr = new Gio.UnixInputStream({fd: stderr, close_fd: true});
       new Gio.UnixOutputStream({fd: stdin, close_fd: true}).close(null);
-      new Gio.UnixInputStream({fd: stderr, close_fd: true}).close(null);
 
       this._childWatch = GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, Lang.bind(this, function(pid, status, requestObj) {
         GLib.source_remove(this._childWatch);
@@ -236,6 +236,7 @@ const Future = new Lang.Class({
           global.log(e.toString());
         }
         this._stdout.close(null);
+		this._stderr.close(null);
         return;
       }
 

--- a/utilities.js
+++ b/utilities.js
@@ -214,7 +214,7 @@ const Future = new Lang.Class({
                       null /* child_setup */);
       this._stdout = new Gio.UnixInputStream({fd: stdout, close_fd: true});
       this._dataStdout = new Gio.DataInputStream({base_stream: this._stdout});
-	  this._stderr = new Gio.UnixInputStream({fd: stderr, close_fd: true});
+      this._stderr = new Gio.UnixInputStream({fd: stderr, close_fd: true});
       new Gio.UnixOutputStream({fd: stdin, close_fd: true}).close(null);
 
       this._childWatch = GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, Lang.bind(this, function(pid, status, requestObj) {
@@ -236,7 +236,7 @@ const Future = new Lang.Class({
           global.log(e.toString());
         }
         this._stdout.close(null);
-		this._stderr.close(null);
+        this._stderr.close(null);
         return;
       }
 


### PR DESCRIPTION
I noticed that when I had my WiFi adapter turned off, all devices would be missing from the extension status and it would be telling me to re-run sensors-detect even though the command line outputs just fine. I traced this to a premature closing of the `stderr` stream from the child process causing all the childs fds to get cleaned up. 

When a device is disabled, `sensors` spits up an error while reading it, and writes this to `stderr` while also writing "N/A" for the temperature reading on `stdout`. It seems that for whatever reason, if `stderr` is used by the child process, it needs to be closed **after** we are completely done reading from the child process or it will also close `stdout` causing the extension to think that nothing was output by `sensors` and that no devices have been configured. 

This patch corrects the problem by storing `stderr` and closing it once we are done with `stdout`. I also tried using the [SpawnFlags.STDERR_TO_DEV_NULL](https://people.gnome.org/~gcampagna/docs/GLib-2.0/GLib.SpawnFlags.html) which, in my mind, is the better way to handle this situation, but it seems like the javascript bindings are not hooked up correctly because no matter what I tried I had a failed assertion. 

With the patch applied, the disabled device will simply disappear from the list of devices shown in the extension. I toyed with other ideas, such as displaying the N/A, or displaying something like "Off" or "Disabled" for that device but I decided to keep it as simple as possible pending feedback from the developers. If you would like some kind of display like that, rather than the device simply not showing when it is disabled, let me know and I can submit it in another PR.
