### PR TITLE
Support for Gnome 3.30

### DIFF
--- a/convenience.js
+++ b/convenience.js
@@ -7,6 +7,8 @@ const Gtk = imports.gi.Gtk;
 const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
 
+const ByteArray = imports.byteArray;
+
 /**
  * initTranslations:
  * @domain: (optional): the gettext domain to use
@@ -79,4 +81,30 @@ function getSettings(schema) {
             + extension.metadata.uuid + '. Please check your installation.');
 
   return new Gio.Settings({ settings_schema: schemaObj });
+}
+
+/**
+ * byteArrayToString:
+ * @byte_array: the byte_array to decode a UTF-8 string from
+ *
+ * This is a compatibility wrapper. Since gjs 1.54 the custom ByteArray has
+ * been removed and replaced by the standardized Uint8Array type.
+ * The uint8_array.to_String() will not return the amused UTF-8 string in gjs
+ * version > 1.54 but a string with the decimal digits of each byte joined with
+ * commas.
+ *
+ * The recommended way to get a UTF-8 decoded string from a Uint8Array is to
+ * use the static function ByteArray.toString(byte_array) which is available
+ * with gjs 1.54.
+ *
+ * To remain compatible with gjs < 1.54 this helper function checks for the
+ * instance type of the byte_array and calls the correct function to decode the
+ * UTF-8 string.
+ */
+function byteArrayToString (byte_array) {
+    if (byte_array instanceof ByteArray.ByteArray) {
+        return byte_array.toString();
+    } else if (byte_array instanceof Uint8Array) {
+        return ByteArray.toString(byte_array);
+    }
 }

--- a/extension.js
+++ b/extension.js
@@ -153,7 +153,7 @@ const SensorsMenuButton = new Lang.Class({
       let sum = 0; //sum
       let max = 0; //max temp
       let allCoreTemps = '';
-      for each (let temp in tempInfo){
+      tempInfo.forEach((temp)=> {
         sum += temp.temp;
         if (temp.temp > max)
           max = temp.temp;
@@ -167,7 +167,7 @@ const SensorsMenuButton = new Lang.Class({
             }
             allCoreTemps += _("%s ").format(this._formatTemp(temp.temp));
         }
-      }
+      });
 
       if (tempInfo.length > 0){
         sensorsList.push(new PopupMenu.PopupSeparatorMenuItem());
@@ -181,19 +181,19 @@ const SensorsMenuButton = new Lang.Class({
           sensorsList.push(new PopupMenu.PopupSeparatorMenuItem());
       }
 
-      for each (let fan in fanInfo){
+      fanInfo.forEach((fan)=> {
         sensorsList.push(new SensorsItem('fan', fan.label, _("%drpm").format(fan['rpm'])));
-      }
+      });
       if (fanInfo.length > 0 && voltageInfo.length > 0){
         sensorsList.push(new PopupMenu.PopupSeparatorMenuItem());
       }
-      for each (let voltage in voltageInfo){
+      voltageInfo.forEach((voltage)=> {
         sensorsList.push(new SensorsItem('voltage', voltage.label, _("%s%.2fV").format(((voltage['volt'] >= 0) ? '+' : '-'), voltage['volt'])));
-      }
+      });
 
       this.statusLabel.set_text(_("N/A")); // Just in case
 
-      for each (let item in sensorsList) {
+      sensorsList.forEach((item)=> {
         if(item instanceof SensorsItem) {
           if (settings.get_string('main-sensor') == item.getLabel()) {
 
@@ -203,7 +203,7 @@ const SensorsMenuButton = new Lang.Class({
           }
         }
         section.addMenuItem(item);
-      }
+      });
 
       // separator
       section.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,9 @@
     "3.20",
     "3.22",
     "3.24",
-    "3.26"
+    "3.26",
+    "3.28",
+    "3.30"
   ],
   "url": "https://github.com/HarlemSquirrel/gnome-shell-extension-sensors",
   "uuid": "sensory-perception@HarlemSquirrel.github.io",

--- a/prefs.js
+++ b/prefs.js
@@ -149,9 +149,9 @@ const SensorsPrefsWidget = new GObject.Class({
   },
 
   _appendMultipleItems: function(sensorInfo) {
-    for each (let sensor in sensorInfo) {
+    sensorInfo.forEach((sensor)=> {
       this._model.set(this._model.append(), [modelColumn.label], [sensor['label']]);
-    }
+    });
   },
 
   _appendSeparator: function() {

--- a/prefs.js
+++ b/prefs.js
@@ -164,7 +164,7 @@ const SensorsPrefsWidget = new GObject.Class({
       let sensors_output = GLib.spawn_command_line_sync(sensors_cmd.join(' '));
       if(sensors_output[0])
       {
-        let output = sensors_output[1].toString();
+        let output = Convenience.byteArrayToString(sensors_output[1]);
         let tempInfo = Utilities.parseSensorsOutput(output,Utilities.parseSensorsTemperatureLine);
         tempInfo = tempInfo.filter(Utilities.filterTemperature);
         this._appendMultipleItems(tempInfo);

--- a/prefs.js
+++ b/prefs.js
@@ -204,7 +204,7 @@ const SensorsPrefsWidget = new GObject.Class({
 
   _getActiveSensorIter: function() {
     /* Get the first iter in the list */
-    [success, iter] = this._model.get_iter_first();
+    let [success, iter] = this._model.get_iter_first();
     let sensorLabel = this._model.get_value(iter, 0);
 
     while (success) {

--- a/prefs.js
+++ b/prefs.js
@@ -121,7 +121,7 @@ const SensorsPrefsWidget = new GObject.Class({
     // ComboBox to select which sensor to show in panel
     this._sensorSelector = new Gtk.ComboBox({ model: this._model });
     this._sensorSelector.set_active_iter(this._getActiveSensorIter());
-    this._sensorSelector.set_row_separator_func(Lang.bind(this, this._comboBoxSeparator), null, null);
+    this._sensorSelector.set_row_separator_func(Lang.bind(this, this._comboBoxSeparator));
 
     let renderer = new Gtk.CellRendererText();
     this._sensorSelector.pack_start(renderer, true);

--- a/utilities.js
+++ b/utilities.js
@@ -201,7 +201,7 @@ function filterVoltage(voltageInfo) {
   return true;
 }
 
-const Future = new Lang.Class({
+var Future = new Lang.Class({
   Name: 'Future',
 
 	_init: function(argv, callback) {
@@ -268,7 +268,7 @@ function debug(str){
 }
 
 // routines for handling of udisks2
-const UDisks = {
+var UDisks = {
   // creates a list of sensor objects from the list of proxies given
   create_list_from_proxies: function(proxies) {
     return proxies.filter(function(proxy) {

--- a/utilities.js
+++ b/utilities.js
@@ -175,8 +175,7 @@ function parseHddTempOutput(txt, sep) {
   hddtemp_output = hddtemp_output.filter(function(e){ return e; });
 
   let sensors = new Array();
-  for each(let line in hddtemp_output)
-  {
+  hddtemp_output.forEach((line)=> {
     let sensor = new Array();
     let fields = line.split(sep).filter(function(e){ return e; });
     sensor['label'] = _("Drive %s").format(fields[0].split('/').pop());
@@ -184,7 +183,7 @@ function parseHddTempOutput(txt, sep) {
     //push only if the temp is a Number
     if (!isNaN(sensor['temp']))
       sensors.push(sensor);
-  }
+  });
   return sensors;
 }
 

--- a/utilities.js
+++ b/utilities.js
@@ -3,6 +3,7 @@ const GObject = imports.gi.GObject;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Convenience = Me.imports.convenience;
 const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
 const _ = Gettext.gettext;
 
@@ -41,9 +42,9 @@ function detectHDDTemp() {
   let pid = undefined;
 
   if(systemctl) {
-    let activeState = GLib.spawn_command_line_sync(systemctl + " show hddtemp.service -p ActiveState")[1].toString().trim();
+    let activeState = Convenience.byteArrayToString(GLib.spawn_command_line_sync(systemctl + " show hddtemp.service -p ActiveState")[1]).trim();
     if(activeState == "ActiveState=active") {
-      let output = GLib.spawn_command_line_sync(systemctl + " show hddtemp.service -p MainPID")[1].toString().trim();
+      let output = Convenience.byteArrayToString(GLib.spawn_command_line_sync(systemctl + " show hddtemp.service -p MainPID")[1]).trim();
 
       if(output.length && output.split("=").length == 2) {
         pid = Number(output.split("=")[1].trim());
@@ -53,7 +54,7 @@ function detectHDDTemp() {
 
   // systemd isn't used on this system, try sysvinit instead
   if(!pid && pidof) {
-    let output = GLib.spawn_command_line_sync("pidof hddtemp")[1].toString().trim();
+    let output = Convenience.byteArrayToString(GLib.spawn_command_line_sync("pidof hddtemp")[1]).trim();
 
     if(output.length) {
       pid = Number(output.trim());
@@ -230,7 +231,7 @@ const Future = new Lang.Class({
     this._dataStdout.fill_async(-1, GLib.PRIORITY_DEFAULT, null, Lang.bind(this, function(stream, result) {
       if (stream.fill_finish(result) == 0){
         try{
-          this._callback(stream.peek_buffer().toString());
+          this._callback(Convenience.byteArrayToString(stream.peek_buffer()));
         }catch(e){
           global.log(e.toString());
         }

--- a/utilities.js
+++ b/utilities.js
@@ -85,6 +85,7 @@ function parseSensorsOutput(txt,parser) {
   for(let i = 0; i < sensors_output.length; i++){
     // ignore chipset driver name and 'Adapter:' line for now
     i += 2;
+    if (i > sensors_output.length) break;
     // get every feature of the chip
     while(sensors_output[i]){
        // if it is not a continutation of a feature line


### PR DESCRIPTION
Hi this PR fixes compatibility with gnome 3.30 and gjs 1.54.

825bc04 is needed for the extension to work at all since the custom `for each` loops where removed from gjs 1.54.

The rest fixes warnings.

The changes should be at least backwards compatible with gnome 3.28 with gjs 1.52.