### PR TITLE
Fix extension not showing voltages below 1 volt

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -211,7 +211,7 @@ class SensoryPerception_SensorsMenuButton extends PanelMenu.Button {
                 sensorsList.push(new PopupMenu.PopupSeparatorMenuItem());
             }
             for (const voltage of voltageInfo){
-                sensorsList.push(new SensorsItem('voltage', voltage.label, _("%s%.2fV").format(((voltage['volt'] >= 0) ? '+' : '-'), voltage['volt'])));
+                sensorsList.push(new SensorsItem('voltage', voltage.label, _("%s%.3fV").format(((voltage['volt'] >= 0) ? '+' : '-'), voltage['volt'])));
             }
 
             this.statusLabel.set_text(_("N/A")); // Just in case

--- a/utilities.js
+++ b/utilities.js
@@ -172,20 +172,23 @@ function parseFanRPMLine(label, value) {
 }
 
 function parseVoltageLine(label, value) {
-    let sensor = undefined;
-    if(label != undefined && value != undefined) {
-        const curValue = value.trim().split('  ')[0];
-        // does the current value look like a voltage line?
-        if(curValue.indexOf("V", curValue.length - "V".length) !== -1) {
-            sensor = new Array();
-            let r;
-            sensor['label'] = label.trim();
-            sensor['volt'] = parseFloat(curValue.split(' ')[0]);
-            sensor['min'] = (r = /min=(\d{1,3}.\d)/.exec(value)) ? parseFloat(r[1]) : undefined;
-            sensor['max'] = (r = /max=(\d{1,3}.\d)/.exec(value)) ? parseFloat(r[1]) : undefined;
-        }
+  let sensor = undefined;
+  if(label != undefined && value != undefined) {
+    const regex = /\s+([\d\.]+)\s+(m?V)\s+\(min\s+\=\s+\+([\d\.]+)\sV,\smax\s\=\s+\+([\d\.]+)/;
+    const matchValue = value.match(regex);
+    // does the current value look like a voltage line?
+    if(matchValue) {
+      sensor = new Array();
+      sensor['label'] = label;
+      sensor['volt'] = parseFloat(matchValue[1]);
+      sensor['min'] = parseFloat(matchValue[3]);
+      sensor['max'] = parseFloat(matchValue[4]);
+      if(matchValue[2] == "mV") {
+      	sensor['volt'] = sensor['volt'] / 1000.0;
+      }
     }
-    return sensor;
+  }
+  return sensor;
 }
 
 function parseHddTempOutput(txt, sep) {

--- a/utilities.js
+++ b/utilities.js
@@ -172,20 +172,20 @@ function parseFanRPMLine(label, value) {
 }
 
 function parseVoltageLine(label, value) {
-  let sensor = undefined;
-  if(label != undefined && value != undefined) {
-    const regex = /\s+([\d\.]+)\s+(m?V)\s+\(min\s+\=\s+\+([\d\.]+)\sV,\smax\s\=\s+\+([\d\.]+)/;
-    const matchValue = value.match(regex);
-    // does the current value look like a voltage line?
-    if(matchValue) {
-      sensor = new Array();
-      sensor['label'] = label;
-      sensor['volt'] = parseFloat(matchValue[1]);
-      sensor['min'] = parseFloat(matchValue[3]);
-      sensor['max'] = parseFloat(matchValue[4]);
-      if(matchValue[2] == "mV") {
-      	sensor['volt'] = sensor['volt'] / 1000.0;
-      }
+    let sensor = undefined;
+    if(label != undefined && value != undefined) {
+        const regex = /\s+([\d\.]+)\s+(m?V)\s+\(min\s+\=\s+\+([\d\.]+)\sV,\smax\s\=\s+\+([\d\.]+)/;
+        const matchValue = value.match(regex);
+        // does the current value look like a voltage line?
+        if(matchValue) {
+            sensor = new Array();
+            sensor['label'] = label;
+            sensor['volt'] = parseFloat(matchValue[1]);
+            sensor['min'] = parseFloat(matchValue[3]);
+            sensor['max'] = parseFloat(matchValue[4]);
+            if(matchValue[2] == "mV") {
+                sensor['volt'] = sensor['volt'] / 1000.0;
+            }
     }
   }
   return sensor;

--- a/utilities.js
+++ b/utilities.js
@@ -187,8 +187,8 @@ function parseVoltageLine(label, value) {
                 sensor['volt'] = sensor['volt'] / 1000.0;
             }
     }
-  }
-  return sensor;
+    }
+    return sensor;
 }
 
 function parseHddTempOutput(txt, sep) {


### PR DESCRIPTION
Fixed parsing of sensors voltage lines.
Changed display of voltage values to show three decimals instead of two (to cater for millivolt values).

Fixes #21 