### PR TITLE
Add support for GNOME 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "settings-schema": "org.gnome.shell.extensions.sensory-perception",
   "shell-version": [
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/HarlemSquirrel/gnome-shell-extension-sensory-perception",
   "uuid": "sensory-perception@HarlemSquirrel.github.io",


### PR DESCRIPTION
Add version 42 to the supported versions in the metadata. No further actions are necessary to make the extension works.